### PR TITLE
Fix argparse default password to match DEFAULT_PASSWORD

### DIFF
--- a/sonic/docker/backup.sh
+++ b/sonic/docker/backup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 DEFAULT_USER="admin"
-DEFAULT_PASSWORD="YourPaSsWoRd"
+DEFAULT_PASSWORD="Nexthop@24"
 REMOTE_FILE="/etc/sonic/config_db.json"
 TMP_FILE="/tmp/${REMOTE_FILE##*/}"
 BACKUP_FILE="/config/${REMOTE_FILE##*/}"

--- a/sonic/docker/backup.sh
+++ b/sonic/docker/backup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 DEFAULT_USER="admin"
-DEFAULT_PASSWORD="admin"
+DEFAULT_PASSWORD="YourPaSsWoRd"
 REMOTE_FILE="/etc/sonic/config_db.json"
 TMP_FILE="/tmp/${REMOTE_FILE##*/}"
 BACKUP_FILE="/config/${REMOTE_FILE##*/}"

--- a/sonic/docker/launch.py
+++ b/sonic/docker/launch.py
@@ -145,7 +145,7 @@ if __name__ == "__main__":
     )
     parser.add_argument("--hostname", default="sonic", help="SONiC hostname")
     parser.add_argument("--username", default="admin", help="Username")
-    parser.add_argument("--password", default="admin", help="Password")
+    parser.add_argument("--password", default=DEFAULT_PASSWORD, help="Password")
     parser.add_argument(
         "--connection-mode", default="tc", help="Connection mode to use in the datapath"
     )

--- a/sonic/docker/launch.py
+++ b/sonic/docker/launch.py
@@ -12,7 +12,7 @@ import vrnetlab
 
 CONFIG_FILE = "/config/config_db.json"
 DEFAULT_USER = "admin"
-DEFAULT_PASSWORD = "YourPaSsWoRd"
+DEFAULT_PASSWORD = "Nexthop@24"
 
 
 def handle_SIGCHLD(_signal, _frame):


### PR DESCRIPTION
## Summary

Align the default password in argparse with the constant DEFAULT_PASSWORD (Nexthop@24) to ensure consistency across the codebase.

## Description

Currently, the script defines:
```
DEFAULT_USER = "admin"
DEFAULT_PASSWORD = "YourPaSsWoRd"
```
but the argparse section sets:

```
parser.add_argument("--password", default="admin", help="Password")
```
This causes an inconsistency where:
	•	The VM is initially accessed with the hardcoded DEFAULT_PASSWORD (YourPaSsWoRd).
	•	If no --password is provided, argparse overwrites it with "admin" instead of the intended default.

Fix:
Updated the argparse default for --password to use DEFAULT_PASSWORD.
This ensures:
	•	Default login remains consistent (admin / YourPaSsWoRd).
	•	User-provided --password values continue to override as expected.
